### PR TITLE
Import category sort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 node_modules
 *.log
 *.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -11,3 +11,4 @@ create_config.sh
 *.coffee
 release-as-zip.sh
 package
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,7 @@ src
 test
 tmp
 config.js
+.sphere-project-credentials
 coverage
 .travis.yml
 .coveralls.yml

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -64,7 +64,7 @@ module.exports = (grunt) ->
     # watching for changes
     watch:
       default:
-        files: ["src/coffee/*.coffee"]
+        files: ["src/coffee/**/*.coffee"]
         tasks: ["build"]
       test:
         files: ["src/**/*.coffee"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Usage: bin/category-sync -p <project-key> import -f <CSV file>
 
 Options:
   -f, --file  CSV file name                          [required]
+  --sort      Sort CSV file before importing
 
 Examples:
   bin/category-sync -p my-project-42          Import categories from
@@ -62,6 +63,8 @@ Examples:
 During import we match categories to existing categories according to the `externalId`. If a category with the same `externalId` is found we will call it an update as the tool will then update the existing category properties - like name etc. - to those values defined in the CSV file.
 If no matching category is found the tool will create a new one.
 The `import` sub-command will never delete a category.
+
+When importing categories, the right order has to be provided to ensure that the category parent already exists before importing a category. For this purpose you can specify a `--sort` parameter which will preprocess categories and sort them before importing.
 
 ## Export
 

--- a/create_config.sh
+++ b/create_config.sh
@@ -9,6 +9,6 @@ exports.config = {
 }
 EOF
 
-cat > "${HOME}/.sphere-project-credentials" << EOF
+cat > ".sphere-project-credentials" << EOF
 ${SPHERE_PROJECT_KEY}:${SPHERE_CLIENT_ID}:${SPHERE_CLIENT_SECRET}
 EOF

--- a/src/coffee/csv/categorysort.coffee
+++ b/src/coffee/csv/categorysort.coffee
@@ -23,7 +23,7 @@ class CategorySort
 
     # if parentBy is externalId or ID just return value from a row by headerIndex
     if cons.HEADER_SLUG == parentBy
-      parentBy = cons.HEADER_SLUG+'.'+@options.language
+      parentBy = cons.HEADER_SLUG + '.' + @options.language
 
     @getValueByHeader(row, header, parentBy)
 
@@ -75,7 +75,7 @@ class CategorySort
 
       if data.length == dataToProcess.length and dataToProcess.length
         @logger.debug("SortingCycle::Could not find parents anymore,"
-          + " flushing the res of #{dataToProcess.length} rows")
+          +" flushing the res of #{dataToProcess.length} rows")
 
         outBuffer = outBuffer.concat _.pluck(dataToProcess, 'row')
         dataToProcess = []

--- a/src/coffee/csv/categorysort.coffee
+++ b/src/coffee/csv/categorysort.coffee
@@ -1,0 +1,87 @@
+fs = require 'fs'
+_ = require 'underscore'
+str = require 'underscore.string'
+cons = require './constants'
+
+class CategorySort
+
+  constructor: (@logger, @options = {}) ->
+    @logger.debug 'Sort::init', {
+      parentBy: @options.parentBy,
+      language: @options.language
+    }
+
+  getValueByHeader: (row, header, colName) ->
+    index = header.indexOf(colName)
+    if index < 0
+      throw new Error("CSV header does not have #{colName} column")
+    str.trim(row[index], '"')
+
+  # will take externalId, id or slug.language (eg: slug.de) from csv row
+  getRowId: (row, header) ->
+    parentBy = @options.parentBy || cons.HEADER_EXTERNAL_ID
+
+    # if parentBy is externalId or ID just return value from a row by headerIndex
+    if cons.HEADER_SLUG == parentBy
+      parentBy = cons.HEADER_SLUG+'.'+@options.language
+
+    @getValueByHeader(row, header, parentBy)
+
+  parseRow: (row, header) ->
+    parsed = row.split(',')
+    {
+      row: row,
+      parentId: @getValueByHeader(parsed, header, cons.HEADER_PARENT_ID),
+      rowId: @getRowId(parsed, header)
+    }
+
+  sort: (fileIn, fileOut) ->
+    parentMap = {}
+    processed = {}
+    outBuffer = []
+    dataToProcess = []
+
+    rows = fs.readFileSync(fileIn, "utf-8").split "\n"
+    if rows.length <= 1
+      return
+
+    outBuffer.push(rows.shift())
+    header = outBuffer[0].split(',')
+
+    # preprocess: parse id and parentIds
+    rows.forEach (row) =>
+      if row.length
+        parsed = @parseRow(row, header)
+        dataToProcess.push parsed
+        parentMap[parsed.rowId] = parsed.parentId
+
+    # fill missing parents
+    dataToProcess.forEach (row) ->
+      if row.parentId and not (row.parentId in parentMap)
+        parentMap[row.parentId] = ''
+
+    # sort: write rows but only if parents have been already written
+    while dataToProcess.length
+      @logger.debug("SortingCycle::Processing batch of #{dataToProcess.length} lines", )
+      data = dataToProcess
+      dataToProcess = []
+
+      data.forEach (row) ->
+        if row.parentId == '' or processed[row.parentId]
+          processed[row.rowId] = 1
+          outBuffer.push(row.row)
+        else
+          dataToProcess.push row
+
+      @logger.debug("SortingCycle::Batch of #{dataToProcess.length} rows left")
+
+      if data.length == dataToProcess.length and dataToProcess.length
+        @logger.debug("SortingCycle::Could not find parents anymore,"
+          + " flushing the res of #{dataToProcess.length} rows")
+
+        outBuffer = outBuffer.concat _.pluck(dataToProcess, 'row')
+        dataToProcess = []
+
+    fs.writeFileSync(fileOut, outBuffer.join('\n'), 'utf-8')
+
+module.exports = CategorySort

--- a/src/coffee/csv/categorysort.coffee
+++ b/src/coffee/csv/categorysort.coffee
@@ -42,8 +42,6 @@ class CategorySort
     dataToProcess = []
 
     rows = fs.readFileSync(fileIn, "utf-8").split "\n"
-    if rows.length <= 1
-      return
 
     outBuffer.push(rows.shift())
     header = outBuffer[0].split(',')

--- a/src/coffee/csv/importer.coffee
+++ b/src/coffee/csv/importer.coffee
@@ -4,15 +4,26 @@ fs = require 'fs'
 csv = require 'csv'
 transform = require 'stream-transform'
 ImportMapping = require './importmapping'
+CategorySort = require './categorysort'
 Streaming = require '../streaming'
 Promise = require 'bluebird'
 
 class Importer
 
-  constructor: (@logger, options = {}) ->
-    @streaming = new Streaming @logger, options
+  constructor: (@logger, @options = {}) ->
+    @streaming = new Streaming @logger, @options
+
+  sortCategories: (fileName) ->
+    sortedFileName = fileName + '-sorted'
+    categorySort = new CategorySort(@logger, @options)
+    categorySort.sort fileName, sortedFileName
+    sortedFileName
 
   run: (fileName) ->
+
+    if @options.sort
+      fileName = @sortCategories(fileName)
+
     rowCount = 2
     new Promise (resolve, reject) =>
       input = fs.createReadStream fileName

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -107,11 +107,15 @@ ensureCredentials(argv)
     .usage 'Usage: $0 -p <project-key> import -f <CSV file>'
     .example '$0 -p my-project-42 import -f categories.csv', 'Import categories from "categories.csv" file into SPHERE project with key "my-project-42".'
 
+    .describe 'sort', 'Sort categories by parentId before importing'
+
     .describe 'f', 'CSV file name'
     .nargs 'f', 1
     .alias 'f', 'file'
     .demand 'f'
     .argv
+
+    options.sort = argv.sort
 
     im = new Importer logger, options
     im.run argv.f

--- a/src/spec/csv/categorysort.spec.coffee
+++ b/src/spec/csv/categorysort.spec.coffee
@@ -1,0 +1,137 @@
+fs = require 'fs'
+CategorySort = require '../../lib/csv/categorysort'
+{ExtendedLogger} = require 'sphere-node-utils'
+
+tempFile = '/tmp/categories.csv'
+resultFile = '/tmp/categories.csv-sorted'
+
+describe 'CategorySort', ->
+  beforeEach ->
+    @logger = new ExtendedLogger()
+    @sorter = new CategorySort(@logger)
+
+
+  describe '#constructor', ->
+    runTest = (input, output, sorter) ->
+      fs.writeFileSync tempFile, input.join('\n')
+      sorter.sort tempFile, resultFile
+      expect(fs.readFileSync(resultFile, 'utf-8')).toEqual output.join('\n')
+
+    it 'should initialize', ->
+      expect(@sorter).toBeDefined()
+
+    it 'should sort an empty file', ->
+      input = ['']
+      runTest(input, input, @sorter)
+
+    it 'should sort a file only with header', ->
+      input = ['id,parentId,externalId']
+      runTest(input, input, @sorter)
+
+    it 'should sort a file by externalId', ->
+      input = [
+        'id,externalId,parentId',
+        'c,3,1',
+        'd,4,3',
+        'a,1,',
+        'b,2,1',
+        'e,5,4',
+        'e,6,'
+      ]
+
+      expected = [
+        'id,externalId,parentId',
+        'a,1,',
+        'b,2,1',
+        'e,6,'
+        'c,3,1',
+        'd,4,3',
+        'e,5,4',
+      ]
+
+      runTest(input, expected, @sorter)
+
+    it 'should sort a file with loops', ->
+      input = [
+        'id,externalId,parentId',
+        'c,3,1',
+        'd,4,3',
+        'a,1,',
+        'b,2,1',
+        'e,5,6',
+        'f,6,5'
+      ]
+
+      expected = [
+        'id,externalId,parentId',
+        'a,1,',
+        'b,2,1',
+        'c,3,1',
+        'd,4,3',
+        'e,5,6',
+        'f,6,5'
+      ]
+
+      runTest(input, expected, @sorter)
+
+    it 'should sort a file with missing parents', ->
+      input = [
+        'id,externalId,parentId',
+        'c,3,4',
+        'a,1,',
+        'b,2,1',
+      ]
+
+      expected = [
+        'id,externalId,parentId',
+        'a,1,',
+        'b,2,1',
+        'c,3,4',
+      ]
+
+      runTest(input, expected, @sorter)
+
+    it 'should sort a file by slug', ->
+      sorter = new CategorySort @logger,
+        parentBy: 'slug'
+        language: 'en'
+
+      input = [
+        'id,externalId,parentId,slug.en',
+        'c,3,bbb,ccc',
+        'b,2,aaa,bbb',
+        'e,2,ddd,eee',
+        'a,1,,aaa',
+      ]
+
+      expected = [
+        'id,externalId,parentId,slug.en',
+        'a,1,,aaa',
+        'b,2,aaa,bbb',
+        'c,3,bbb,ccc',
+        'e,2,ddd,eee',
+      ]
+
+      runTest(input, expected, sorter)
+
+    it 'should sort a file by id', ->
+      sorter = new CategorySort @logger,
+        parentBy: 'id'
+
+      input = [
+        'id,externalId,parentId',
+        'c,3,b',
+        'a,1,',
+        'b,2,a',
+        'e,2,d',
+      ]
+
+      expected = [
+        'id,externalId,parentId',
+        'a,1,',
+        'b,2,a',
+        'c,3,b',
+        'e,2,d',
+      ]
+
+      runTest(input, expected, sorter)


### PR DESCRIPTION
This PR contains several changes:
 - ignore several files
 - watching for builds also in subfolders
 - add `--sort` parameter which will sort categories before import

It resolves a problem which occurs when importing categories before their parents.