### PR TITLE
Import - category sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 node_modules
 *.log
 *.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -11,3 +11,4 @@ create_config.sh
 *.coffee
 release-as-zip.sh
 package
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,7 @@ src
 test
 tmp
 config.js
+.sphere-project-credentials
 coverage
 .travis.yml
 .coveralls.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,3 @@ notifications:
     format: html
     on_success: change
     on_failure: change
-env:
-  global:
-  - secure: c3GzzEEiT7TVEjLgPAFOV5SXMG+X0M9j8iiyh1oGtKfRbp66uk3VyY2wEMivoGeJjodGAGyOMDla8Fl3/+37aOQ9QujsDKSvxo+kZVX0LQ5r5BFeIraH9Ln3jJFimGpfzQYA3yjvnfRVNOQEH6WVTBB8+G7w4kq77785oFbMxtI=
-  - secure: d8ZBYxVisrrgtCCGiOYspFthxuQHJrdsK1nXjMZqxUrepdIm6dOySu4fFUCY5rv4q1jFB0WtChmoyDuGacqFnXD432l/oQiTD4FN56wlovsFvrGQytO8ZcTB7R7JO+jhQFTA/CIu9mxhyeI739xzDzGh3ksYRmrlfCgPXVa0oAQ=
-  - secure: CxWNoBhePuKDpcqRofyZEqW2wSokE5lgq1C2VzZGQXnWLcBbxg4za7hS3azaKh1R9Psd/93ZcFMaSx7xyexE3bkueiMQHRZ7wzuwUkGkCoBy0gRPuFHCg4zp3AybzUbXQ/H0Cmr9h65VBMEWXqVuJJ9R0pcETcBQ+Gb1hgczFqc=

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -64,7 +64,7 @@ module.exports = (grunt) ->
     # watching for changes
     watch:
       default:
-        files: ["src/coffee/*.coffee"]
+        files: ["src/coffee/**/*.coffee"]
         tasks: ["build"]
       test:
         files: ["src/**/*.coffee"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Usage: bin/category-sync -p <project-key> import -f <CSV file>
 
 Options:
   -f, --file  CSV file name                          [required]
+  --sort      Sort CSV file before importing
 
 Examples:
   bin/category-sync -p my-project-42          Import categories from
@@ -62,6 +63,8 @@ Examples:
 During import we match categories to existing categories according to the `externalId`. If a category with the same `externalId` is found we will call it an update as the tool will then update the existing category properties - like name etc. - to those values defined in the CSV file.
 If no matching category is found the tool will create a new one.
 The `import` sub-command will never delete a category.
+
+When importing categories, the right order has to be provided to ensure that the category parent already exists before importing a category. For this purpose you can specify a `--sort` parameter which will preprocess categories and sort them before importing.
 
 ## Export
 

--- a/create_config.sh
+++ b/create_config.sh
@@ -9,6 +9,6 @@ exports.config = {
 }
 EOF
 
-cat > "${HOME}/.sphere-project-credentials" << EOF
+cat > ".sphere-project-credentials" << EOF
 ${SPHERE_PROJECT_KEY}:${SPHERE_CLIENT_ID}:${SPHERE_CLIENT_SECRET}
 EOF

--- a/create_config.sh
+++ b/create_config.sh
@@ -9,6 +9,6 @@ exports.config = {
 }
 EOF
 
-cat > ".sphere-project-credentials" << EOF
+cat > "${HOME}/.sphere-project-credentials" << EOF
 ${SPHERE_PROJECT_KEY}:${SPHERE_CLIENT_ID}:${SPHERE_CLIENT_SECRET}
 EOF

--- a/features/export.feature
+++ b/features/export.feature
@@ -34,7 +34,7 @@ Feature: Export categories
     When I run `category-sync -p sphere-category-sync-test export -o no-template.csv`
     Then the exit status should be 0
     Then a file named "no-template.csv" should exist
-    And the file "no-template.csv" should match /^id,externalId,parentId,orderHint,createdAt,lastModifiedAt,name.de,description.de,slug.de,metaTitle.de,metaDescription.de,metaKeywords.de$/
+    And the file "no-template.csv" should match /^id,externalId,parentId,orderHint,createdAt,lastModifiedAt,name.en,description.en,slug.en,metaTitle.en,metaDescription.en,metaKeywords.en/
 
   Scenario: Use externalId for parentId during Export
     Given a file named "single.csv" with:

--- a/features/export.feature
+++ b/features/export.feature
@@ -1,7 +1,7 @@
 Feature: Export categories
 
   Scenario: Error on wrong template file
-    When I run `category-sync -p import-101-64 export -t not_here.csv -o output.csv`
+    When I run `category-sync -p sphere-category-sync-test export -t not_here.csv -o output.csv`
     Then the exit status should be 1
     And the output should contain "Error: ENOENT"
     And the output should contain "open 'not_here.csv'"
@@ -11,7 +11,7 @@ Feature: Export categories
     """
     id
     """
-    When I run `category-sync -p import-101-64 export -t template.csv -o /output.csv`
+    When I run `category-sync -p sphere-category-sync-test export -t template.csv -o /output.csv`
     Then the exit status should be 1
     And the output should contain "Error: EACCES"
     And the output should contain "open '/output.csv'"
@@ -22,16 +22,16 @@ Feature: Export categories
     name.en,slug.en
     Some Export Category,some-export-category
     """
-    When I run `category-sync -p import-101-64 import -f single.csv`
+    When I run `category-sync -p sphere-category-sync-test import -f single.csv`
     Then the exit status should be 0
-    When I run `category-sync -p import-101-64 export -t single.csv -o output1.csv`
+    When I run `category-sync -p sphere-category-sync-test export -t single.csv -o output1.csv`
     Then the exit status should be 0
     Then a file named "output1.csv" should exist
     And the file "output1.csv" should match /^name.en,slug.en$/
     And the file "output1.csv" should match /^Some Export Category,some-export-category$/
 
   Scenario: Export works without template
-    When I run `category-sync -p import-101-64 export -o no-template.csv`
+    When I run `category-sync -p sphere-category-sync-test export -o no-template.csv`
     Then the exit status should be 0
     Then a file named "no-template.csv" should exist
     And the file "no-template.csv" should match /^id,externalId,parentId,orderHint,createdAt,lastModifiedAt,name.de,description.de,slug.de,metaTitle.de,metaDescription.de,metaKeywords.de$/
@@ -44,13 +44,13 @@ Feature: Export categories
     e-2,Bar,bar,e-1
     e-3,Baz,baz,e-1
     """
-    When I run `category-sync -p import-101-64 import -f single.csv`
+    When I run `category-sync -p sphere-category-sync-test import -f single.csv`
     Then the exit status should be 0
     Given a file named "externalId-parentId.csv" with:
     """
     externalId,parentId
     """
-    When I run `category-sync -p import-101-64 export --parentBy externalId -t externalId-parentId.csv -o output3.csv`
+    When I run `category-sync -p sphere-category-sync-test export --parentBy externalId -t externalId-parentId.csv -o output3.csv`
     Then the exit status should be 0
     Then a file named "output3.csv" should exist
     And the file "output3.csv" should match /^externalId,parentId$/
@@ -65,9 +65,9 @@ Feature: Export categories
     exId1,Nice Stuff,nice-stuff,It's very nice stuff - bla bla,nice stuff,SEO magic for the nice stuff,nice;stuff,0.1
     exId2,Old Stuff,old-stuff,It's pretty old stuff - foo bar,old stuff,even more SEO magic needed for old stuff,stuff;old,0.9,exId1
     """
-    When I run `category-sync -p import-101-64 import -f full.csv`
+    When I run `category-sync -p sphere-category-sync-test import -f full.csv`
     Then the exit status should be 0
-    When I run `category-sync -p import-101-64 export -t full.csv -o output.csv`
+    When I run `category-sync -p sphere-category-sync-test export -t full.csv -o output.csv`
     Then the exit status should be 0
     Then a file named "output.csv" should exist
     And the file "output.csv" should match /^externalId,name.en,slug.en,description.en,metaTitle.en,metaDescription.en,metaKeywords.en,orderHint,parentId$/
@@ -78,7 +78,7 @@ Feature: Export categories
     """
     externalId,id,createdAt,lastModifiedAt,parentId
     """
-    When I run `category-sync -p import-101-64 --parentBy slug export -t template.csv -o output2.csv`
+    When I run `category-sync -p sphere-category-sync-test --parentBy slug export -t template.csv -o output2.csv`
     Then the exit status should be 0
     Then a file named "output2.csv" should exist
     And the file "output2.csv" should match /^externalId,id,createdAt,lastModifiedAt,parentId$/

--- a/features/import.feature
+++ b/features/import.feature
@@ -2,7 +2,7 @@ Feature: Import categories
 
   @wip
   Scenario: Error on wrong file
-    When I run `category-sync -p import-101-64 import -f not_here.csv`
+    When I run `category-sync -p sphere-category-sync-test import -f not_here.csv`
     Then the exit status should be 1
     And the output should contain "Error: ENOENT"
     And the output should contain "open 'not_here.csv'"
@@ -13,7 +13,7 @@ Feature: Import categories
     name.en,slug.en
     Some Category,some-category
     """
-    When I run `category-sync -p import-101-64 import -f single.csv --verbose`
+    When I run `category-sync -p sphere-category-sync-test import -f single.csv --verbose`
     Then the exit status should be 0
     And the output should contain "Processing '1' category"
     And the output should contain "Import done."
@@ -25,7 +25,7 @@ Feature: Import categories
     rootCat,Root Category,root-category,
     subCat,Sub Category,sub-category,rootCat
     """
-    When I run `category-sync -p import-101-64 import -f simple-tree.csv --verbose`
+    When I run `category-sync -p sphere-category-sync-test import -f simple-tree.csv --verbose`
     Then the exit status should be 0
     And the output should contain "Found parent for 'rootCat' using externalId (language: en)."
     And the output should contain "Import done."
@@ -39,7 +39,7 @@ Feature: Import categories
     Sub Sub Category 1,x,sub-category-slug
     Sub Sub Category 2,y,sub-category-slug
     """
-    When I run `category-sync -p import-101-64 import --parentBy slug -f import-by-slug.csv --verbose`
+    When I run `category-sync -p sphere-category-sync-test import --parentBy slug -f import-by-slug.csv --verbose`
     Then the exit status should be 0
     And the output should contain "Found parent for 'root-slug' using slug (language: en)."
     And the output should contain "Found parent for 'sub-category-slug' using slug (language: en)."
@@ -51,7 +51,7 @@ Feature: Import categories
     name.en,slug.en,parentId
     A Category,a-slug,Not Existing!!!
     """
-    When I run `category-sync --continueOnProblems -p import-101-64 import -f problem.csv --verbose`
+    When I run `category-sync --continueOnProblems -p sphere-category-sync-test import -f problem.csv --verbose`
     Then the exit status should be 0
     And the output should contain "Could not resolve parent for 'Not Existing!!!' using externalId (language: en)."
     And the output should contain "Import done."
@@ -64,15 +64,15 @@ Feature: Import categories
     Sub,slug2,sub42,root42
     Root,slug3,root42
     """
-    When I run `category-sync --continueOnProblems -p import-101-64 import -f loop.csv --verbose`
+    When I run `category-sync --continueOnProblems -p sphere-category-sync-test import -f loop.csv --verbose`
     Then the exit status should be 0
     And the output should contain "Could not resolve parent for 'sub42' using externalId (language: en). - ignored!"
     And the output should contain "Could not resolve parent for 'root42' using externalId (language: en). - ignored!"
-    When I run `category-sync --continueOnProblems -p import-101-64 import -f loop.csv --verbose`
+    When I run `category-sync --continueOnProblems -p sphere-category-sync-test import -f loop.csv --verbose`
     Then the exit status should be 0
     And the output should contain "Could not resolve parent for 'sub42' using externalId (language: en). - ignored!"
     And the output should contain "Found parent for 'root42' using externalId"
-    When I run `category-sync --continueOnProblems -p import-101-64 import -f loop.csv --verbose`
+    When I run `category-sync --continueOnProblems -p sphere-category-sync-test import -f loop.csv --verbose`
     Then the exit status should be 0
     And the output should contain "Found parent for 'sub42' using externalId"
     And the output should contain "Found parent for 'root42' using externalId"

--- a/features/update.feature
+++ b/features/update.feature
@@ -6,9 +6,9 @@ Feature: Update categories
     externalId,name.en,slug.en,orderHint
     exId1,Category to update,category-to-update,0.1
     """
-    When I run `category-sync -p import-101-64 import -f update.csv --verbose`
+    When I run `category-sync -p sphere-category-sync-test import -f update.csv --verbose`
     Then the exit status should be 0
-    When I run `category-sync -p import-101-64 import -f update.csv --verbose`
+    When I run `category-sync -p sphere-category-sync-test import -f update.csv --verbose`
     Then the exit status should be 0
     And the output should contain "Processing '1' category"
     And the output should contain "Found candidates: 1"

--- a/src/coffee/csv/categorysort.coffee
+++ b/src/coffee/csv/categorysort.coffee
@@ -23,7 +23,7 @@ class CategorySort
 
     # if parentBy is externalId or ID just return value from a row by headerIndex
     if cons.HEADER_SLUG == parentBy
-      parentBy = cons.HEADER_SLUG+'.'+@options.language
+      parentBy = cons.HEADER_SLUG + '.' + @options.language
 
     @getValueByHeader(row, header, parentBy)
 
@@ -75,7 +75,7 @@ class CategorySort
 
       if data.length == dataToProcess.length and dataToProcess.length
         @logger.debug("SortingCycle::Could not find parents anymore,"
-          + " flushing the res of #{dataToProcess.length} rows")
+          +" flushing the res of #{dataToProcess.length} rows")
 
         outBuffer = outBuffer.concat _.pluck(dataToProcess, 'row')
         dataToProcess = []

--- a/src/coffee/csv/categorysort.coffee
+++ b/src/coffee/csv/categorysort.coffee
@@ -1,0 +1,87 @@
+fs = require 'fs'
+_ = require 'underscore'
+str = require 'underscore.string'
+cons = require './constants'
+
+class CategorySort
+
+  constructor: (@logger, @options = {}) ->
+    @logger.debug 'Sort::init', {
+      parentBy: @options.parentBy,
+      language: @options.language
+    }
+
+  getValueByHeader: (row, header, colName) ->
+    index = header.indexOf(colName)
+    if index < 0
+      throw new Error("CSV header does not have #{colName} column")
+    str.trim(row[index], '"')
+
+  # will take externalId, id or slug.language (eg: slug.de) from csv row
+  getRowId: (row, header) ->
+    parentBy = @options.parentBy || cons.HEADER_EXTERNAL_ID
+
+    # if parentBy is externalId or ID just return value from a row by headerIndex
+    if cons.HEADER_SLUG == parentBy
+      parentBy = cons.HEADER_SLUG+'.'+@options.language
+
+    @getValueByHeader(row, header, parentBy)
+
+  parseRow: (row, header) ->
+    parsed = row.split(',')
+    {
+      row: row,
+      parentId: @getValueByHeader(parsed, header, cons.HEADER_PARENT_ID),
+      rowId: @getRowId(parsed, header)
+    }
+
+  sort: (fileIn, fileOut) ->
+    parentMap = {}
+    processed = {}
+    outBuffer = []
+    dataToProcess = []
+
+    rows = fs.readFileSync(fileIn, "utf-8").split "\n"
+    if rows.length <= 1
+      return
+
+    outBuffer.push(rows.shift())
+    header = outBuffer[0].split(',')
+
+    # preprocess: parse id and parentIds
+    rows.forEach (row) =>
+      if row.length
+        parsed = @parseRow(row, header)
+        dataToProcess.push parsed
+        parentMap[parsed.rowId] = parsed.parentId
+
+    # fill missing parents
+    dataToProcess.forEach (row) ->
+      if row.parentId and not (row.parentId in parentMap)
+        parentMap[row.parentId] = ''
+
+    # sort: write rows but only if parents have been already written
+    while dataToProcess.length
+      @logger.debug("SortingCycle::Processing batch of #{dataToProcess.length} lines", )
+      data = dataToProcess
+      dataToProcess = []
+
+      data.forEach (row) ->
+        if row.parentId == '' or processed[row.parentId]
+          processed[row.rowId] = 1
+          outBuffer.push(row.row)
+        else
+          dataToProcess.push row
+
+      @logger.debug("SortingCycle::Batch of #{dataToProcess.length} rows left")
+
+      if data.length == dataToProcess.length and dataToProcess.length
+        @logger.debug("SortingCycle::Could not find parents anymore,"
+          + " flushing the res of #{dataToProcess.length} rows")
+
+        outBuffer = outBuffer.concat _.pluck(dataToProcess, 'row')
+        dataToProcess = []
+
+    fs.writeFileSync(fileOut, outBuffer.join('\n'), 'utf-8')
+
+module.exports = CategorySort

--- a/src/coffee/csv/categorysort.coffee
+++ b/src/coffee/csv/categorysort.coffee
@@ -42,8 +42,6 @@ class CategorySort
     dataToProcess = []
 
     rows = fs.readFileSync(fileIn, "utf-8").split "\n"
-    if rows.length <= 1
-      return
 
     outBuffer.push(rows.shift())
     header = outBuffer[0].split(',')

--- a/src/coffee/csv/importer.coffee
+++ b/src/coffee/csv/importer.coffee
@@ -4,15 +4,26 @@ fs = require 'fs'
 csv = require 'csv'
 transform = require 'stream-transform'
 ImportMapping = require './importmapping'
+CategorySort = require './categorysort'
 Streaming = require '../streaming'
 Promise = require 'bluebird'
 
 class Importer
 
-  constructor: (@logger, options = {}) ->
-    @streaming = new Streaming @logger, options
+  constructor: (@logger, @options = {}) ->
+    @streaming = new Streaming @logger, @options
+
+  sortCategories: (fileName) ->
+    sortedFileName = fileName + '-sorted'
+    categorySort = new CategorySort(@logger, @options)
+    categorySort.sort fileName, sortedFileName
+    sortedFileName
 
   run: (fileName) ->
+
+    if @options.sort
+      fileName = @sortCategories(fileName)
+
     rowCount = 2
     new Promise (resolve, reject) =>
       input = fs.createReadStream fileName

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -107,11 +107,15 @@ ensureCredentials(argv)
     .usage 'Usage: $0 -p <project-key> import -f <CSV file>'
     .example '$0 -p my-project-42 import -f categories.csv', 'Import categories from "categories.csv" file into SPHERE project with key "my-project-42".'
 
+    .describe 'sort', 'Sort categories by parentId before importing'
+
     .describe 'f', 'CSV file name'
     .nargs 'f', 1
     .alias 'f', 'file'
     .demand 'f'
     .argv
+
+    options.sort = argv.sort
 
     im = new Importer logger, options
     im.run argv.f

--- a/src/spec/csv/categorysort.spec.coffee
+++ b/src/spec/csv/categorysort.spec.coffee
@@ -1,0 +1,137 @@
+fs = require 'fs'
+CategorySort = require '../../lib/csv/categorysort'
+{ExtendedLogger} = require 'sphere-node-utils'
+
+tempFile = '/tmp/categories.csv'
+resultFile = '/tmp/categories.csv-sorted'
+
+describe 'CategorySort', ->
+  beforeEach ->
+    @logger = new ExtendedLogger()
+    @sorter = new CategorySort(@logger)
+
+
+  describe '#constructor', ->
+    runTest = (input, output, sorter) ->
+      fs.writeFileSync tempFile, input.join('\n')
+      sorter.sort tempFile, resultFile
+      expect(fs.readFileSync(resultFile, 'utf-8')).toEqual output.join('\n')
+
+    it 'should initialize', ->
+      expect(@sorter).toBeDefined()
+
+    it 'should sort an empty file', ->
+      input = ['']
+      runTest(input, input, @sorter)
+
+    it 'should sort a file only with header', ->
+      input = ['id,parentId,externalId']
+      runTest(input, input, @sorter)
+
+    it 'should sort a file by externalId', ->
+      input = [
+        'id,externalId,parentId',
+        'c,3,1',
+        'd,4,3',
+        'a,1,',
+        'b,2,1',
+        'e,5,4',
+        'e,6,'
+      ]
+
+      expected = [
+        'id,externalId,parentId',
+        'a,1,',
+        'b,2,1',
+        'e,6,'
+        'c,3,1',
+        'd,4,3',
+        'e,5,4',
+      ]
+
+      runTest(input, expected, @sorter)
+
+    it 'should sort a file with loops', ->
+      input = [
+        'id,externalId,parentId',
+        'c,3,1',
+        'd,4,3',
+        'a,1,',
+        'b,2,1',
+        'e,5,6',
+        'f,6,5'
+      ]
+
+      expected = [
+        'id,externalId,parentId',
+        'a,1,',
+        'b,2,1',
+        'c,3,1',
+        'd,4,3',
+        'e,5,6',
+        'f,6,5'
+      ]
+
+      runTest(input, expected, @sorter)
+
+    it 'should sort a file with missing parents', ->
+      input = [
+        'id,externalId,parentId',
+        'c,3,4',
+        'a,1,',
+        'b,2,1',
+      ]
+
+      expected = [
+        'id,externalId,parentId',
+        'a,1,',
+        'b,2,1',
+        'c,3,4',
+      ]
+
+      runTest(input, expected, @sorter)
+
+    it 'should sort a file by slug', ->
+      sorter = new CategorySort @logger,
+        parentBy: 'slug'
+        language: 'en'
+
+      input = [
+        'id,externalId,parentId,slug.en',
+        'c,3,bbb,ccc',
+        'b,2,aaa,bbb',
+        'e,2,ddd,eee',
+        'a,1,,aaa',
+      ]
+
+      expected = [
+        'id,externalId,parentId,slug.en',
+        'a,1,,aaa',
+        'b,2,aaa,bbb',
+        'c,3,bbb,ccc',
+        'e,2,ddd,eee',
+      ]
+
+      runTest(input, expected, sorter)
+
+    it 'should sort a file by id', ->
+      sorter = new CategorySort @logger,
+        parentBy: 'id'
+
+      input = [
+        'id,externalId,parentId',
+        'c,3,b',
+        'a,1,',
+        'b,2,a',
+        'e,2,d',
+      ]
+
+      expected = [
+        'id,externalId,parentId',
+        'a,1,',
+        'b,2,a',
+        'c,3,b',
+        'e,2,d',
+      ]
+
+      runTest(input, expected, sorter)


### PR DESCRIPTION
This PR contains several changes:
 - ignore several files
 - watching for builds also in subfolders
 - add `--sort` parameter which will sort categories before import

It resolves a problem which occurs when importing categories before their parents.