### PR TITLE
fix(import): Fix issue with lost data when importing category diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,12 +41,13 @@
     "csv-stringify": "0.0.8",
     "debug": "2.2.0",
     "highland": "2.5.1",
+    "lodash.merge": "^4.6.0",
     "sphere-node-sdk": "1.7.0",
     "sphere-node-utils": "0.7.0",
     "stream-transform": "0.1.0",
     "underscore": "1.8.3",
-    "underscore.string": "3.1.1",
     "underscore-mixins": "0.1.4",
+    "underscore.string": "3.1.1",
     "yargs": "3.15.0"
   },
   "devDependencies": {

--- a/src/coffee/apiclient.coffee
+++ b/src/coffee/apiclient.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore'
 _.mixin require 'underscore-mixins'
+loMerge = require 'lodash.merge'
 Promise = require 'bluebird'
 {SphereClient, CategorySync} = require 'sphere-node-sdk'
 
@@ -28,6 +29,7 @@ class ApiClient
     .fetch()
 
   update: (category, existingCategory, actionsToIgnore = [], context = {}) ->
+    category = loMerge({}, existingCategory, category)
     @logger.debug "performing update"
     new Promise (resolve, reject) =>
       actionsToSync = @sync


### PR DESCRIPTION
#### Summary
Fixes #51

#### Description
When there is not provided a description field in CSV when running update action, this field will get lost.

#### Todo

- Tests
    - [ ] Unit
    - [x] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
