### PR TITLE
Fix handling ids when used in parentBy parameter

### DIFF
--- a/src/coffee/csv/exporter.coffee
+++ b/src/coffee/csv/exporter.coffee
@@ -6,7 +6,6 @@ stringify = require 'csv-stringify'
 transform = require 'stream-transform'
 CONS = require './constants'
 ExportMapping = require './exportmapping'
-Streaming = require '../streaming'
 {SphereClient} = require 'sphere-node-sdk'
 Promise = require 'bluebird'
 
@@ -40,7 +39,7 @@ class Exporter
     @write [rawHeader] # pass array of array to ensure newline in CSV
 
   defaultTemplate: ->
-    new Promise (resolve, reject) =>
+    new Promise (resolve) =>
       header = CONS.BASE_HEADERS
       @client.project.fetch()
       .then (prj) =>
@@ -70,7 +69,7 @@ class Exporter
 
         processChunk = (payload) =>
           @logger.info "Processing #{_.size payload.body.results} categories"
-          new Promise (resolve, reject) =>
+          new Promise (resolve) =>
             rows = _.map payload.body.results, (category) =>
               row = @mapping.toCSV category
             @write rows
@@ -80,11 +79,11 @@ class Exporter
         @client.categories
         .expand('parent')
         .process(processChunk, {accumulate: false})
-        .then (result) =>
+        .then =>
           @stream.end()
 
   write: (output) ->
-    new Promise (resolve, reject) =>
+    new Promise (resolve) =>
       stringify output, (err, out) =>
         @stream.write out
         resolve 'OK'

--- a/src/coffee/csv/importer.coffee
+++ b/src/coffee/csv/importer.coffee
@@ -53,6 +53,10 @@ class Importer
           console.log "Process row: " + rowCount
           @logger.debug 'chunk: ', chunk, {}
           @streaming.processStream [ chunk ], cb # TODO: better passing of chunk
+          .catch (err) =>
+            @logger.error err
+            reject err
+
           rowCount = rowCount + chunkSize
         , {parallel: chunkSize})
 

--- a/src/coffee/matcher.coffee
+++ b/src/coffee/matcher.coffee
@@ -34,7 +34,7 @@ class Matcher
 
   resolveParent: (category) ->
     new Promise (resolve, reject) =>
-      _resolve = (cat, parentId) =>
+      _resolve = (cat, parentId) ->
         cat.parent.id = parentId
         cat.parent.typeId = 'category'
         delete cat.parent._rawParentId
@@ -61,7 +61,7 @@ class Matcher
               else
                 @logger.info msg
                 reject msg
-          .catch (err) =>
+          .catch (err) ->
             reject "Problem on resolving #{msgAppendix}: #{err}"
       else
         resolve category

--- a/src/coffee/matcher.coffee
+++ b/src/coffee/matcher.coffee
@@ -15,6 +15,7 @@ class Matcher
 
   addMapping: (category) ->
     @logger.info "Add mapping for exernalId: '#{category.externalId}' -> id: '#{category.id}'"
+    @existingIds.push category.id
     @externalId2IdMap[category.externalId] = category.id
     if category.slug
       @slug2IdMap[category.slug[@language]] = category.id
@@ -33,8 +34,7 @@ class Matcher
 
   resolveParent: (category) ->
     new Promise (resolve, reject) =>
-      _resolve = (cat, parentId) ->
-        @existingIds.push(parentId)
+      _resolve = (cat, parentId) =>
         cat.parent.id = parentId
         cat.parent.typeId = 'category'
         delete cat.parent._rawParentId

--- a/src/coffee/streaming.coffee
+++ b/src/coffee/streaming.coffee
@@ -6,10 +6,10 @@ Matcher = require './matcher'
 
 class Streaming
 
-  constructor: (@logger, options) ->
-    @apiClient = new ApiClient @logger, options
-    @matcher = new Matcher @logger, @apiClient, options
-    @actionsToIgnore = options.actionsToIgnore
+  constructor: (@logger, @options) ->
+    @apiClient = new ApiClient @logger, @options
+    @matcher = new Matcher @logger, @apiClient, @options
+    @actionsToIgnore = @options.actionsToIgnore
     @_resetSummary()
 
   _resetSummary: =>
@@ -30,8 +30,6 @@ class Streaming
     .then =>
       @logger.info 'Chunk of stream processed'
       cb()
-    .catch (err) =>
-      @logger.error err
 
   _processBatches: (categories) =>
     @logger.info "Processing '#{_.size categories}' categor#{if _.size(categories) is 1 then 'y' else 'ies'}"
@@ -57,6 +55,11 @@ class Streaming
                   else
                     @logger.warn result
                   Promise.resolve result
+        .catch (err) =>
+          if @options.continueOnProblems
+            @logger.error err
+          else
+            Promise.reject err
       , {concurrency: 1} # 1 category at a time
 
 

--- a/src/spec/apiclient.spec.coffee
+++ b/src/spec/apiclient.spec.coffee
@@ -59,7 +59,7 @@ describe 'ApiClient', ->
       .then (res) ->
         done("creation should end in problem, but: #{res}")
       .catch (err) ->
-        expect(err).toMatch /Problem on creating new category/
+        expect(err).toMatch /Error on creating new category/
         done()
 
     it 'should resolve promise on data problems in continueOnProblems mode', (done) ->


### PR DESCRIPTION
#### Summary
Fixes #58

#### Description
A current version of an importer does not check the existence of a parent category identified by its id. This PR adds this check plus it refactors several parts of the code so it is more readable.

#### Todo

- Tests
    - [x] Unit
    - [x] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
