### PR TITLE
feat(import): Set sorting before import to true as a default

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ The command line to import or update categories is shown below:
 Usage: bin/category-sync -p <project-key> import -f <CSV file>
 
 Options:
-  -f, --file  CSV file name                          [required]
-  --sort      Sort CSV file before importing
+  -f, --file            CSV file name                          [required]
+  --sort true/false     Sort CSV file before importing (default: true)
 
 Examples:
   bin/category-sync -p my-project-42          Import categories from

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Usage: bin/category-sync -p <project-key> import -f <CSV file>
 
 Options:
   -f, --file            CSV file name                          [required]
-  --sort true/false     Sort CSV file before importing (default: true)
+  --sort true/false     Sort CSV file before importing  [boolean] [default: true]
 
 Examples:
   bin/category-sync -p my-project-42          Import categories from

--- a/features/import.feature
+++ b/features/import.feature
@@ -63,7 +63,7 @@ Feature: Import categories
     Sub,slug2,sub42,root42
     Root,slug3,root42
     """
-    When I run `category-sync --continueOnProblems -p sphere-category-sync-test import -f loop.csv --verbose`
+    When I run `category-sync --continueOnProblems -p sphere-category-sync-test import -f loop.csv --sort false --verbose`
     Then the exit status should be 0
     And the output should contain "Could not resolve parent for 'sub42' using externalId (language: en). - ignored!"
     And the output should contain "Could not resolve parent for 'root42' using externalId (language: en). - ignored!"
@@ -75,4 +75,17 @@ Feature: Import categories
     Then the exit status should be 0
     And the output should contain "Found parent for 'sub42' using externalId"
     And the output should contain "Found parent for 'root42' using externalId"
+    And the output should contain "Import done."
+
+  Scenario: Sort by default
+    Given a file named "data.csv" with:
+    """
+    name.en,slug.en,externalId,parentId
+    Sub Sub,slug1,sub-sub42,sub42
+    Sub,slug2,sub42,root42
+    Root,slug3,root42
+    """
+    When I run `category-sync --continueOnProblems -p sphere-category-sync-test import -f data.csv --verbose`
+    Then the exit status should be 0
+    And the output should not contain "Could not resolve parent for"
     And the output should contain "Import done."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sphere-category-sync",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/coffee/csv/categorysort.coffee
+++ b/src/coffee/csv/categorysort.coffee
@@ -11,10 +11,13 @@ class CategorySort
       language: @options.language
     }
 
-  getValueByHeader: (row, header, colName) ->
+  getValueByHeader: (row, header, colName, defaultValue) ->
     index = header.indexOf(colName)
     if index < 0
-      throw new Error("CSV header does not have #{colName} column")
+      if _.isUndefined defaultValue
+        throw new Error("CSV header does not have #{colName} column")
+      else
+        return defaultValue
     str.trim(row[index], '"')
 
   # will take externalId, id or slug.language (eg: slug.de) from csv row
@@ -25,13 +28,13 @@ class CategorySort
     if cons.HEADER_SLUG == parentBy
       parentBy = cons.HEADER_SLUG + '.' + @options.language
 
-    @getValueByHeader(row, header, parentBy)
+    @getValueByHeader(row, header, parentBy, '')
 
   parseRow: (row, header) ->
     parsed = row.split(',')
     {
       row: row,
-      parentId: @getValueByHeader(parsed, header, cons.HEADER_PARENT_ID),
+      parentId: @getValueByHeader(parsed, header, cons.HEADER_PARENT_ID, ''),
       rowId: @getRowId(parsed, header)
     }
 

--- a/src/coffee/csv/categorysort.coffee
+++ b/src/coffee/csv/categorysort.coffee
@@ -11,6 +11,8 @@ class CategorySort
       language: @options.language
     }
 
+  # if defaultValue is set use it for missing column - for example when the parentBy
+  # is missing use empty string instead so the new categories as created as a root categories
   getValueByHeader: (row, header, colName, defaultValue) ->
     index = header.indexOf(colName)
     if index < 0

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -94,7 +94,6 @@ ensureCredentials(argv)
     language: language
     parentBy: parentBy
     continueOnProblems: continueOnProblems
-    sort: true
 
   options.host = argv.sphereHost if argv.sphereHost
   options.protocol = argv.sphereProtocol if argv.sphereProtocol
@@ -104,12 +103,12 @@ ensureCredentials(argv)
   options.oauth_protocol = argv.sphereAuthProtocol if argv.sphereAuthProtocol
 
   if command is 'import'
-    yargs.reset()
+    args = yargs.reset()
     .usage 'Usage: $0 -p <project-key> import -f <CSV file>'
     .example '$0 -p my-project-42 import -f categories.csv', 'Import categories from "categories.csv" file into SPHERE project with key "my-project-42".'
-
-    .describe 'sort true/false', 'Sort categories by parentId before importing (default: true)'
-
+    .describe 'sort', 'Sort categories by parentId before importing.'
+    .boolean 'sort'
+    .default 'sort', true
     .describe 'f', 'CSV file name'
     .nargs 'f', 1
     .alias 'f', 'file'
@@ -117,8 +116,7 @@ ensureCredentials(argv)
     .argv
 
     # Sort feature can be disabled by providing --sort false or --sort 0 param
-    if argv.sort == 'false' or argv.sort == 0
-      options.sort = false
+    options.sort = args.sort
 
     im = new Importer logger, options
     im.run argv.f

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -106,9 +106,11 @@ ensureCredentials(argv)
     args = yargs.reset()
     .usage 'Usage: $0 -p <project-key> import -f <CSV file>'
     .example '$0 -p my-project-42 import -f categories.csv', 'Import categories from "categories.csv" file into SPHERE project with key "my-project-42".'
+
     .describe 'sort', 'Sort categories by parentId before importing.'
     .boolean 'sort'
     .default 'sort', true
+
     .describe 'f', 'CSV file name'
     .nargs 'f', 1
     .alias 'f', 'file'

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -94,6 +94,7 @@ ensureCredentials(argv)
     language: language
     parentBy: parentBy
     continueOnProblems: continueOnProblems
+    sort: true
 
   options.host = argv.sphereHost if argv.sphereHost
   options.protocol = argv.sphereProtocol if argv.sphereProtocol
@@ -107,7 +108,7 @@ ensureCredentials(argv)
     .usage 'Usage: $0 -p <project-key> import -f <CSV file>'
     .example '$0 -p my-project-42 import -f categories.csv', 'Import categories from "categories.csv" file into SPHERE project with key "my-project-42".'
 
-    .describe 'sort', 'Sort categories by parentId before importing'
+    .describe 'sort true/false', 'Sort categories by parentId before importing (default: true)'
 
     .describe 'f', 'CSV file name'
     .nargs 'f', 1
@@ -115,7 +116,9 @@ ensureCredentials(argv)
     .demand 'f'
     .argv
 
-    options.sort = argv.sort
+    # Sort feature can be disabled by providing --sort false or --sort 0 param
+    if argv.sort == 'false' or argv.sort == 0
+      options.sort = false
 
     im = new Importer logger, options
     im.run argv.f


### PR DESCRIPTION
#### Summary
Resolves #56

This PR sets `--sort true` parameter as a default. The sorting feature can be disabled by `--sort false` or `--sort 0`. All other options (eg: `--sort`, `--sort true`, or not provided at all) will resolve as `sort = true`