### PR TITLE
chore(travis-CI): add node v8 to CI and remove v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ branches:
   except:
   - latest
 node_js:
-- '4'
 - '6'
+- '8'
 before_script:
 - npm install -g grunt-cli
 - ./create_config.sh

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "main": "./lib",
   "engines": {
-    "node": ">= 4"
+    "node": ">= 6.0.0"
   },
   "scripts": {
     "build": "grunt build",


### PR DESCRIPTION
#### Summary
Add node v8 to CI and remove v4

#### Description

- Add of node v8 to CI and remove v4 in sphere-category-sync

- Change of engine from node ">= 4" to ">= 6.0.0" in package.json

Part of [this issue](https://github.com/commercetools/nodejs-tasks-board/issues/10)