### PR TITLE
Dependency update due to security alert.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -904,26 +904,6 @@
         }
       }
     },
-    "cryptiles": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.4.tgz",
-      "integrity": "sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==",
-      "dev": true,
-      "requires": {
-        "boom": "5.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        }
-      }
-    },
     "csv": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.5.tgz",


### PR DESCRIPTION
Removed obsolete dependency from lock file.

Not sure if we should remove the lock file anyway?