### PR TITLE
chore(package) drop support of node v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ branches:
   except:
   - latest
 node_js:
-- '6'
 - '8'
+- '10'
 before_script:
 - npm install -g grunt-cli
 - ./create_config.sh

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "main": "./lib",
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 8.0.0"
   },
   "scripts": {
     "build": "grunt build",


### PR DESCRIPTION
#### Summary
This PR drops the support of node v6 as we are going to use resources from [commercetools monorepo](https://github.com/commercetools/nodejs) which does not support v6 anymore.
