### PR TITLE
Resolve references in series

### DIFF
--- a/src/coffee/apiclient.coffee
+++ b/src/coffee/apiclient.coffee
@@ -41,7 +41,7 @@ class ApiClient
 
   getCustomTypeByKey: (key) ->
     if @typesCacheByKey[key] or @typesCacheByKey[key] is null
-      return @typesCacheByKey[key]
+      return Promise.resolve(@typesCacheByKey[key])
 
     @client.types
       .where("key=#{JSON.stringify(key)}")


### PR DESCRIPTION
This PR changes how we resolve references (eg parent category ID) - originally we were resolving references in parallel but now we do it in series so we ensure that parent categories are imported before we start fetching parent category ID.

Ticket: https://github.com/commercetools/express-impex/issues/616